### PR TITLE
style: use chicago font for imprint headings, add bubble image

### DIFF
--- a/scripts/generate-imprint.ts
+++ b/scripts/generate-imprint.ts
@@ -24,7 +24,15 @@ async function generate() {
     <template>
     <main-content>
       <div class="prose mx-auto grid max-w-3xl gap-4 px-8 py-16">
-        <h1 class="text-4xl font-extrabold">Impressum</h1>
+        <div class="relative mb-8">
+          <img alt="" class="absolute -top-8 -left-10 h-28 w-28" src="@/assets/images/bubble.svg" />
+          <h1
+            class="relative flex items-center gap-2 bg-neutral-50 pb-1 font-display text-3xl font-bold"
+          >
+            Impressum
+          </h1>
+          <div class="relative h-1 bg-brand-cyan" />
+        </div>
         ${html}
       </div>
     </main-content>

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,17 +1,11 @@
 .prose {
-  & h1 {
-    margin-bottom: 1.5rem;
-    font-size: 1.8rem;
-  }
-
   & h2 {
-    margin-bottom: 2.5rem;
-    font-size: 1.25rem;
+    @apply my-2 font-display text-xl font-bold;
   }
 
   & h3 {
     margin-block: 2.25rem 1.25rem;
-    font-weight: 600;
+    @apply font-display font-bold;
   }
 
   & br {


### PR DESCRIPTION
- use "chicago" font for headings on imprint page
- add bubble image to main imprint page heading

note: did *not* change footer background color, and did *not* change body text weight to light, because both significantly impact readability.

closes #46